### PR TITLE
Allow deriving a SystemParamBuilder struct when deriving SystemParam.

### DIFF
--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -452,4 +452,31 @@ mod tests {
         let result = world.run_system_once(system);
         assert_eq!(result, 5);
     }
+
+    #[derive(SystemParam)]
+    #[system_param(builder)]
+    struct CustomParam<'w, 's> {
+        query: Query<'w, 's, ()>,
+        local: Local<'s, usize>,
+    }
+
+    #[test]
+    fn custom_param_builder() {
+        let mut world = World::new();
+
+        world.spawn(A);
+        world.spawn_empty();
+
+        let system = (CustomParamBuilder {
+            local: LocalBuilder(100),
+            query: QueryParamBuilder::new(|builder| {
+                builder.with::<A>();
+            }),
+        },)
+            .build_state(&mut world)
+            .build_system(|param: CustomParam| *param.local + param.query.iter().count());
+
+        let result = world.run_system_once(system);
+        assert_eq!(result, 101);
+    }
 }


### PR DESCRIPTION
# Objective

Allow `SystemParamBuilder` implementations for custom system parameters created using `#[derive(SystemParam)]`.  

## Solution

Extend the derive macro to accept a `#[system_param(builder)]` attribute.  When present, emit a builder type with a field corresponding to each field of the param.  

## Example

```rust
#[derive(SystemParam)]
#[system_param(builder)]
struct CustomParam<'w, 's> {
    query: Query<'w, 's, ()>,
    local: Local<'s, usize>,
}

let system = (CustomParamBuilder {
    local: LocalBuilder(100),
    query: QueryParamBuilder::new(|builder| {
        builder.with::<A>();
    }),
},)
    .build_state(&mut world)
    .build_system(|param: CustomParam| *param.local + param.query.iter().count());
```
