### PR TITLE
Borrow Access in FilteredEntity(Ref|Mut) and Entity(Ref|Mut)Except

### DIFF
--- a/crates/bevy_animation/src/keyframes.rs
+++ b/crates/bevy_animation/src/keyframes.rs
@@ -147,7 +147,7 @@ pub trait Keyframes: Reflect + Debug + Send + Sync {
     fn apply_single_keyframe<'a>(
         &self,
         transform: Option<Mut<'a, Transform>>,
-        entity: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        entity: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         weight: f32,
     ) -> Result<(), AnimationEvaluationError>;
 
@@ -178,7 +178,7 @@ pub trait Keyframes: Reflect + Debug + Send + Sync {
     fn apply_tweened_keyframes<'a>(
         &self,
         transform: Option<Mut<'a, Transform>>,
-        entity: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        entity: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         interpolation: Interpolation,
         step_start: usize,
         time: f32,
@@ -278,7 +278,7 @@ impl Keyframes for TranslationKeyframes {
     fn apply_single_keyframe<'a>(
         &self,
         transform: Option<Mut<'a, Transform>>,
-        _: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        _: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         weight: f32,
     ) -> Result<(), AnimationEvaluationError> {
         let mut component = transform.ok_or_else(|| {
@@ -294,7 +294,7 @@ impl Keyframes for TranslationKeyframes {
     fn apply_tweened_keyframes<'a>(
         &self,
         transform: Option<Mut<'a, Transform>>,
-        _: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        _: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         interpolation: Interpolation,
         step_start: usize,
         time: f32,
@@ -333,7 +333,7 @@ impl Keyframes for ScaleKeyframes {
     fn apply_single_keyframe<'a>(
         &self,
         transform: Option<Mut<'a, Transform>>,
-        _: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        _: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         weight: f32,
     ) -> Result<(), AnimationEvaluationError> {
         let mut component = transform.ok_or_else(|| {
@@ -349,7 +349,7 @@ impl Keyframes for ScaleKeyframes {
     fn apply_tweened_keyframes<'a>(
         &self,
         transform: Option<Mut<'a, Transform>>,
-        _: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        _: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         interpolation: Interpolation,
         step_start: usize,
         time: f32,
@@ -388,7 +388,7 @@ impl Keyframes for RotationKeyframes {
     fn apply_single_keyframe<'a>(
         &self,
         transform: Option<Mut<'a, Transform>>,
-        _: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        _: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         weight: f32,
     ) -> Result<(), AnimationEvaluationError> {
         let mut component = transform.ok_or_else(|| {
@@ -404,7 +404,7 @@ impl Keyframes for RotationKeyframes {
     fn apply_tweened_keyframes<'a>(
         &self,
         transform: Option<Mut<'a, Transform>>,
-        _: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        _: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         interpolation: Interpolation,
         step_start: usize,
         time: f32,
@@ -447,7 +447,7 @@ where
     fn apply_single_keyframe<'a>(
         &self,
         _: Option<Mut<'a, Transform>>,
-        mut entity: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        mut entity: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         weight: f32,
     ) -> Result<(), AnimationEvaluationError> {
         let mut component = entity.get_mut::<P::Component>().ok_or_else(|| {
@@ -465,7 +465,7 @@ where
     fn apply_tweened_keyframes<'a>(
         &self,
         _: Option<Mut<'a, Transform>>,
-        mut entity: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        mut entity: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         interpolation: Interpolation,
         step_start: usize,
         time: f32,
@@ -529,7 +529,7 @@ impl Keyframes for MorphWeightsKeyframes {
     fn apply_single_keyframe<'a>(
         &self,
         _: Option<Mut<'a, Transform>>,
-        mut entity: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        mut entity: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         weight: f32,
     ) -> Result<(), AnimationEvaluationError> {
         let mut dest = entity.get_mut::<MorphWeights>().ok_or_else(|| {
@@ -548,7 +548,7 @@ impl Keyframes for MorphWeightsKeyframes {
     fn apply_tweened_keyframes<'a>(
         &self,
         _: Option<Mut<'a, Transform>>,
-        mut entity: EntityMutExcept<'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
+        mut entity: EntityMutExcept<'a, 'a, (Transform, AnimationPlayer, Handle<AnimationGraph>)>,
         interpolation: Interpolation,
         step_start: usize,
         time: f32,

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -109,9 +109,9 @@ pub struct ReflectComponentFns {
     /// Function pointer implementing [`ReflectComponent::contains()`].
     pub contains: fn(FilteredEntityRef) -> bool,
     /// Function pointer implementing [`ReflectComponent::reflect()`].
-    pub reflect: fn(FilteredEntityRef) -> Option<&dyn Reflect>,
+    pub reflect: for<'w> fn(FilteredEntityRef<'w, '_>) -> Option<&'w dyn Reflect>,
     /// Function pointer implementing [`ReflectComponent::reflect_mut()`].
-    pub reflect_mut: fn(FilteredEntityMut) -> Option<Mut<dyn Reflect>>,
+    pub reflect_mut: for<'w> fn(FilteredEntityMut<'w, '_>) -> Option<Mut<'w, dyn Reflect>>,
     /// Function pointer implementing [`ReflectComponent::reflect_unchecked_mut()`].
     ///
     /// # Safety
@@ -168,20 +168,23 @@ impl ReflectComponent {
     }
 
     /// Returns whether entity contains this [`Component`]
-    pub fn contains<'a>(&self, entity: impl Into<FilteredEntityRef<'a>>) -> bool {
+    pub fn contains<'w, 's>(&self, entity: impl Into<FilteredEntityRef<'w, 's>>) -> bool {
         (self.0.contains)(entity.into())
     }
 
     /// Gets the value of this [`Component`] type from the entity as a reflected reference.
-    pub fn reflect<'a>(&self, entity: impl Into<FilteredEntityRef<'a>>) -> Option<&'a dyn Reflect> {
+    pub fn reflect<'w, 's>(
+        &self,
+        entity: impl Into<FilteredEntityRef<'w, 's>>,
+    ) -> Option<&'w dyn Reflect> {
         (self.0.reflect)(entity.into())
     }
 
     /// Gets the value of this [`Component`] type from the entity as a mutable reflected reference.
-    pub fn reflect_mut<'a>(
+    pub fn reflect_mut<'w, 's>(
         &self,
-        entity: impl Into<FilteredEntityMut<'a>>,
-    ) -> Option<Mut<'a, dyn Reflect>> {
+        entity: impl Into<FilteredEntityMut<'w, 's>>,
+    ) -> Option<Mut<'w, dyn Reflect>> {
         (self.0.reflect_mut)(entity.into())
     }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -13,7 +13,7 @@ use crate::{
     world::{DeferredWorld, Mut, World},
 };
 use bevy_ptr::{OwningPtr, Ptr};
-use std::{any::TypeId, marker::PhantomData};
+use std::{any::TypeId, marker::PhantomData, sync::OnceLock};
 use thiserror::Error;
 
 use super::{unsafe_world_cell::UnsafeEntityCell, Ref, ON_REMOVE, ON_REPLACE};
@@ -210,10 +210,10 @@ impl<'a> From<&'a EntityMut<'_>> for EntityRef<'a> {
     }
 }
 
-impl<'a> TryFrom<FilteredEntityRef<'a>> for EntityRef<'a> {
+impl<'a> TryFrom<FilteredEntityRef<'a, '_>> for EntityRef<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(value: FilteredEntityRef<'a>) -> Result<Self, Self::Error> {
+    fn try_from(value: FilteredEntityRef<'a, '_>) -> Result<Self, Self::Error> {
         if !value.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else {
@@ -223,10 +223,10 @@ impl<'a> TryFrom<FilteredEntityRef<'a>> for EntityRef<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a FilteredEntityRef<'_>> for EntityRef<'a> {
+impl<'a> TryFrom<&'a FilteredEntityRef<'_, '_>> for EntityRef<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(value: &'a FilteredEntityRef<'_>) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a FilteredEntityRef<'_, '_>) -> Result<Self, Self::Error> {
         if !value.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else {
@@ -236,10 +236,10 @@ impl<'a> TryFrom<&'a FilteredEntityRef<'_>> for EntityRef<'a> {
     }
 }
 
-impl<'a> TryFrom<FilteredEntityMut<'a>> for EntityRef<'a> {
+impl<'a> TryFrom<FilteredEntityMut<'a, '_>> for EntityRef<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(value: FilteredEntityMut<'a>) -> Result<Self, Self::Error> {
+    fn try_from(value: FilteredEntityMut<'a, '_>) -> Result<Self, Self::Error> {
         if !value.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else {
@@ -249,10 +249,10 @@ impl<'a> TryFrom<FilteredEntityMut<'a>> for EntityRef<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a FilteredEntityMut<'_>> for EntityRef<'a> {
+impl<'a> TryFrom<&'a FilteredEntityMut<'_, '_>> for EntityRef<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(value: &'a FilteredEntityMut<'_>) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a FilteredEntityMut<'_, '_>) -> Result<Self, Self::Error> {
         if !value.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else {
@@ -528,10 +528,10 @@ impl<'a> From<&'a mut EntityWorldMut<'_>> for EntityMut<'a> {
     }
 }
 
-impl<'a> TryFrom<FilteredEntityMut<'a>> for EntityMut<'a> {
+impl<'a> TryFrom<FilteredEntityMut<'a, '_>> for EntityMut<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(value: FilteredEntityMut<'a>) -> Result<Self, Self::Error> {
+    fn try_from(value: FilteredEntityMut<'a, '_>) -> Result<Self, Self::Error> {
         if !value.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else if !value.access.has_write_all() {
@@ -543,10 +543,10 @@ impl<'a> TryFrom<FilteredEntityMut<'a>> for EntityMut<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a mut FilteredEntityMut<'_>> for EntityMut<'a> {
+impl<'a> TryFrom<&'a mut FilteredEntityMut<'_, '_>> for EntityMut<'a> {
     type Error = TryFromFilteredError;
 
-    fn try_from(value: &'a mut FilteredEntityMut<'_>) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a mut FilteredEntityMut<'_, '_>) -> Result<Self, Self::Error> {
         if !value.access.has_read_all() {
             Err(TryFromFilteredError::MissingReadAllAccess)
         } else if !value.access.has_write_all() {
@@ -1900,19 +1900,22 @@ impl<'w, 'a, T: Component> VacantEntry<'w, 'a, T> {
 
 /// Provides read-only access to a single entity and some of its components defined by the contained [`Access`].
 #[derive(Clone)]
-pub struct FilteredEntityRef<'w> {
+pub struct FilteredEntityRef<'w, 's> {
     entity: UnsafeEntityCell<'w>,
-    access: Access<ComponentId>,
+    access: &'s Access<ComponentId>,
 }
 
-impl<'w> FilteredEntityRef<'w> {
+impl<'w, 's> FilteredEntityRef<'w, 's> {
     /// # Safety
     /// - No `&mut World` can exist from the underlying `UnsafeWorldCell`
     /// - If `access` takes read access to a component no mutable reference to that
     ///     component can exist at the same time as the returned [`FilteredEntityMut`]
     /// - If `access` takes any access for a component `entity` must have that component.
     #[inline]
-    pub(crate) unsafe fn new(entity: UnsafeEntityCell<'w>, access: Access<ComponentId>) -> Self {
+    pub(crate) unsafe fn new(
+        entity: UnsafeEntityCell<'w>,
+        access: &'s Access<ComponentId>,
+    ) -> Self {
         Self { entity, access }
     }
 
@@ -1938,7 +1941,7 @@ impl<'w> FilteredEntityRef<'w> {
     /// Returns a reference to the underlying [`Access`].
     #[inline]
     pub fn access(&self) -> &Access<ComponentId> {
-        &self.access
+        self.access
     }
 
     /// Returns `true` if the current entity has a component of type `T`.
@@ -2049,103 +2052,94 @@ impl<'w> FilteredEntityRef<'w> {
     }
 }
 
-impl<'w> From<FilteredEntityMut<'w>> for FilteredEntityRef<'w> {
+impl<'w, 's> From<FilteredEntityMut<'w, 's>> for FilteredEntityRef<'w, 's> {
     #[inline]
-    fn from(entity_mut: FilteredEntityMut<'w>) -> Self {
+    fn from(entity_mut: FilteredEntityMut<'w, 's>) -> Self {
         // SAFETY:
         // - `FilteredEntityMut` guarantees exclusive access to all components in the new `FilteredEntityRef`.
         unsafe { FilteredEntityRef::new(entity_mut.entity, entity_mut.access) }
     }
 }
 
-impl<'a> From<&'a FilteredEntityMut<'_>> for FilteredEntityRef<'a> {
+impl<'a, 's> From<&'a FilteredEntityMut<'_, 's>> for FilteredEntityRef<'a, 's> {
     #[inline]
-    fn from(entity_mut: &'a FilteredEntityMut<'_>) -> Self {
+    fn from(entity_mut: &'a FilteredEntityMut<'_, 's>) -> Self {
         // SAFETY:
         // - `FilteredEntityMut` guarantees exclusive access to all components in the new `FilteredEntityRef`.
-        unsafe { FilteredEntityRef::new(entity_mut.entity, entity_mut.access.clone()) }
+        unsafe { FilteredEntityRef::new(entity_mut.entity, entity_mut.access) }
     }
 }
 
-impl<'a> From<EntityRef<'a>> for FilteredEntityRef<'a> {
+fn read_all_components() -> &'static Access<ComponentId> {
+    static READ_ALL_COMPONENTS: OnceLock<Access<ComponentId>> = OnceLock::new();
+
+    READ_ALL_COMPONENTS.get_or_init(|| {
+        let mut access = Access::new();
+        access.read_all_components();
+        access
+    })
+}
+
+impl<'a> From<EntityRef<'a>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: EntityRef<'a>) -> Self {
         // SAFETY:
         // - `EntityRef` guarantees exclusive access to all components in the new `FilteredEntityRef`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.0, access)
-        }
+        unsafe { FilteredEntityRef::new(entity.0, read_all_components()) }
     }
 }
 
-impl<'a> From<&'a EntityRef<'_>> for FilteredEntityRef<'a> {
+impl<'a> From<&'a EntityRef<'_>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: &'a EntityRef<'_>) -> Self {
         // SAFETY:
         // - `EntityRef` guarantees exclusive access to all components in the new `FilteredEntityRef`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.0, access)
-        }
+        unsafe { FilteredEntityRef::new(entity.0, read_all_components()) }
     }
 }
 
-impl<'a> From<EntityMut<'a>> for FilteredEntityRef<'a> {
+impl<'a> From<EntityMut<'a>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: EntityMut<'a>) -> Self {
         // SAFETY:
         // - `EntityMut` guarantees exclusive access to all components in the new `FilteredEntityRef`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.0, access)
-        }
+        unsafe { FilteredEntityRef::new(entity.0, read_all_components()) }
     }
 }
 
-impl<'a> From<&'a EntityMut<'_>> for FilteredEntityRef<'a> {
+impl<'a> From<&'a EntityMut<'_>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: &'a EntityMut<'_>) -> Self {
         // SAFETY:
         // - `EntityMut` guarantees exclusive access to all components in the new `FilteredEntityRef`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.0, access)
-        }
+        unsafe { FilteredEntityRef::new(entity.0, read_all_components()) }
     }
 }
 
-impl<'a> From<EntityWorldMut<'a>> for FilteredEntityRef<'a> {
+impl<'a> From<EntityWorldMut<'a>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: EntityWorldMut<'a>) -> Self {
         // SAFETY:
         // - `EntityWorldMut` guarantees exclusive access to the entire world.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.into_unsafe_entity_cell(), access)
-        }
+        unsafe { FilteredEntityRef::new(entity.into_unsafe_entity_cell(), read_all_components()) }
     }
 }
 
-impl<'a> From<&'a EntityWorldMut<'_>> for FilteredEntityRef<'a> {
+impl<'a> From<&'a EntityWorldMut<'_>> for FilteredEntityRef<'a, 'static> {
     fn from(entity: &'a EntityWorldMut<'_>) -> Self {
         // SAFETY:
         // - `EntityWorldMut` guarantees exclusive access to the entire world.
         unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            FilteredEntityRef::new(entity.as_unsafe_entity_cell_readonly(), access)
+            FilteredEntityRef::new(
+                entity.as_unsafe_entity_cell_readonly(),
+                read_all_components(),
+            )
         }
     }
 }
 
 /// Provides mutable access to a single entity and some of its components defined by the contained [`Access`].
-pub struct FilteredEntityMut<'w> {
+pub struct FilteredEntityMut<'w, 's> {
     entity: UnsafeEntityCell<'w>,
-    access: Access<ComponentId>,
+    access: &'s Access<ComponentId>,
 }
 
-impl<'w> FilteredEntityMut<'w> {
+impl<'w, 's> FilteredEntityMut<'w, 's> {
     /// # Safety
     /// - No `&mut World` can exist from the underlying `UnsafeWorldCell`
     /// - If `access` takes read access to a component no mutable reference to that
@@ -2154,20 +2148,23 @@ impl<'w> FilteredEntityMut<'w> {
     ///     may exist at the same time as the returned [`FilteredEntityMut`]
     /// - If `access` takes any access for a component `entity` must have that component.
     #[inline]
-    pub(crate) unsafe fn new(entity: UnsafeEntityCell<'w>, access: Access<ComponentId>) -> Self {
+    pub(crate) unsafe fn new(
+        entity: UnsafeEntityCell<'w>,
+        access: &'s Access<ComponentId>,
+    ) -> Self {
         Self { entity, access }
     }
 
     /// Returns a new instance with a shorter lifetime.
     /// This is useful if you have `&mut FilteredEntityMut`, but you need `FilteredEntityMut`.
-    pub fn reborrow(&mut self) -> FilteredEntityMut<'_> {
+    pub fn reborrow(&mut self) -> FilteredEntityMut<'_, 's> {
         // SAFETY: We have exclusive access to the entire entity and its components.
-        unsafe { Self::new(self.entity, self.access.clone()) }
+        unsafe { Self::new(self.entity, self.access) }
     }
 
     /// Gets read-only access to all of the entity's components.
     #[inline]
-    pub fn as_readonly(&self) -> FilteredEntityRef<'_> {
+    pub fn as_readonly(&self) -> FilteredEntityRef<'_, 's> {
         FilteredEntityRef::from(self)
     }
 
@@ -2193,7 +2190,7 @@ impl<'w> FilteredEntityMut<'w> {
     /// Returns a reference to the underlying [`Access`].
     #[inline]
     pub fn access(&self) -> &Access<ComponentId> {
-        &self.access
+        self.access
     }
 
     /// Returns `true` if the current entity has a component of type `T`.
@@ -2323,55 +2320,45 @@ impl<'w> FilteredEntityMut<'w> {
     }
 }
 
-impl<'a> From<EntityMut<'a>> for FilteredEntityMut<'a> {
+fn write_all_components() -> &'static Access<ComponentId> {
+    static WRITE_ALL_COMPONENTS: OnceLock<Access<ComponentId>> = OnceLock::new();
+
+    WRITE_ALL_COMPONENTS.get_or_init(|| {
+        let mut access = Access::new();
+        access.write_all_components();
+        access
+    })
+}
+
+impl<'a> From<EntityMut<'a>> for FilteredEntityMut<'a, 'static> {
     fn from(entity: EntityMut<'a>) -> Self {
         // SAFETY:
         // - `EntityMut` guarantees exclusive access to all components in the new `FilteredEntityMut`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            access.write_all();
-            FilteredEntityMut::new(entity.0, access)
-        }
+        unsafe { FilteredEntityMut::new(entity.0, write_all_components()) }
     }
 }
 
-impl<'a> From<&'a mut EntityMut<'_>> for FilteredEntityMut<'a> {
+impl<'a> From<&'a mut EntityMut<'_>> for FilteredEntityMut<'a, 'static> {
     fn from(entity: &'a mut EntityMut<'_>) -> Self {
         // SAFETY:
         // - `EntityMut` guarantees exclusive access to all components in the new `FilteredEntityMut`.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            access.write_all();
-            FilteredEntityMut::new(entity.0, access)
-        }
+        unsafe { FilteredEntityMut::new(entity.0, write_all_components()) }
     }
 }
 
-impl<'a> From<EntityWorldMut<'a>> for FilteredEntityMut<'a> {
+impl<'a> From<EntityWorldMut<'a>> for FilteredEntityMut<'a, 'static> {
     fn from(entity: EntityWorldMut<'a>) -> Self {
         // SAFETY:
         // - `EntityWorldMut` guarantees exclusive access to the entire world.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            access.write_all();
-            FilteredEntityMut::new(entity.into_unsafe_entity_cell(), access)
-        }
+        unsafe { FilteredEntityMut::new(entity.into_unsafe_entity_cell(), write_all_components()) }
     }
 }
 
-impl<'a> From<&'a mut EntityWorldMut<'_>> for FilteredEntityMut<'a> {
+impl<'a> From<&'a mut EntityWorldMut<'_>> for FilteredEntityMut<'a, 'static> {
     fn from(entity: &'a mut EntityWorldMut<'_>) -> Self {
         // SAFETY:
         // - `EntityWorldMut` guarantees exclusive access to the entire world.
-        unsafe {
-            let mut access = Access::default();
-            access.read_all();
-            access.write_all();
-            FilteredEntityMut::new(entity.as_unsafe_entity_cell(), access)
-        }
+        unsafe { FilteredEntityMut::new(entity.as_unsafe_entity_cell(), write_all_components()) }
     }
 }
 


### PR DESCRIPTION
# Objective

Improve the performance of `FilteredEntity(Ref|Mut)` and `Entity(Ref|Mut)Except`.  

`FilteredEntityRef` needs an `Access<ComponentId>` to determine what components it can access.  There is one stored in the query state, but query items cannot borrow from the state, so it has to `clone()` the access for each row.  Cloning the access involves memory allocations and can be expensive.  

## Solution

Let query items borrow from their query state.  

Have `FilteredEntity(Ref|Mut)` borrow the access from the query state to avoid cloning for each row.

Have `Entity(Ref|Mut)Except` look up the component ids on initialization and store them in an Access that can be borrowed by each row.
